### PR TITLE
Removing the cupertino_icons dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,10 +17,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
-
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
I don't see a reason why the package should depent on a version of cupertino_icons or the package at all.