### PR TITLE
fix: remove "uses-material-design" from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,5 +14,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-flutter:
-  uses-material-design: true


### PR DESCRIPTION
When using this package in  a non-material application, this warning pops up:

```
package:sprung has `uses-material-design: true` set but the primary pubspec contains `uses-material-design: false`.
```

Since I couldn't find any dependency that sprung has on material (nor its icons), removed that statement from the pubspec file.